### PR TITLE
Added Scorchful and updated Farmer's Delight compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,7 @@
 ## Added:
 
-- FarmZ
-- Nature's Delight
-- Rose Gold Equipment
-- Tide 2
-- [Let's Do] Bakery
-- [Let's Do] Beachparty
-- [Let's Do] Brewery
-- [Let's Do] Candlelight
-- [Let's Do] HerbalBrews
-- [Let's Do] Lili's Lucky Lures
-- [Let's Do] Meadow
-- [Let's Do] WilderNature
+- Scorchful `0.15.10` Compat
 
 ## Updated:
 
-- AdventureZ Compat
-- More Delight (for Farmer's Delight)
-- Nature's Spirit Compat
-- [Let's Do] Vinery
+- Farmer's Delight compat for Milk Bottle, Hot Cocoa, Apple Cider, Melon Juice

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
     loader_version=0.18.4
 
 # Mod Properties
-    mod_version=1.1.2
+    mod_version=1.1.3
     maven_group=net.nutritionz
     archives_base_name=nutritionz
 

--- a/src/main/java/net/nutritionz/config/NutritionzConfig.java
+++ b/src/main/java/net/nutritionz/config/NutritionzConfig.java
@@ -115,6 +115,8 @@ public class NutritionzConfig implements ConfigData {
     @ConfigEntry.Gui.RequiresRestart
     public boolean rosegoldequipmentDefaultCompat = true;
     @ConfigEntry.Gui.RequiresRestart
+    public boolean scorchfulDefaultCompat = true;
+    @ConfigEntry.Gui.RequiresRestart
     public boolean thebumblezoneDefaultCompat = true;
     @ConfigEntry.Gui.RequiresRestart
     public boolean tideDefaultCompat = true;

--- a/src/main/java/net/nutritionz/init/EventInit.java
+++ b/src/main/java/net/nutritionz/init/EventInit.java
@@ -159,6 +159,10 @@ public class EventInit {
             ResourceManagerHelper.registerBuiltinResourcePack(Identifier.of("nutritionz", "rosegoldequipment_nutritionz"), FabricLoader.getInstance().getModContainer("nutritionz").orElseThrow(),
                     ResourcePackActivationType.DEFAULT_ENABLED);
         }
+        if (FabricLoader.getInstance().isModLoaded("scorchful") && ConfigInit.CONFIG.misc.scorchfulDefaultCompat) {
+            ResourceManagerHelper.registerBuiltinResourcePack(Identifier.of("nutritionz", "scorchful_nutritionz"), FabricLoader.getInstance().getModContainer("nutritionz").orElseThrow(),
+                    ResourcePackActivationType.DEFAULT_ENABLED);
+        }
         if (FabricLoader.getInstance().isModLoaded("the_bumblezone") && ConfigInit.CONFIG.misc.thebumblezoneDefaultCompat) {
             ResourceManagerHelper.registerBuiltinResourcePack(Identifier.of("nutritionz", "thebumblezone_nutritionz"), FabricLoader.getInstance().getModContainer("nutritionz").orElseThrow(),
                     ResourcePackActivationType.DEFAULT_ENABLED);

--- a/src/main/resources/assets/nutritionz/lang/en_us.json
+++ b/src/main/resources/assets/nutritionz/lang/en_us.json
@@ -65,6 +65,7 @@
     "text.autoconfig.nutritionz.option.misc.livingthingsDefaultCompat": "Living Things",
     "text.autoconfig.nutritionz.option.misc.naturesspiritDefaultCompat": "Nature's Spirit",
     "text.autoconfig.nutritionz.option.misc.rosegoldequipmentDefaultCompat": "Rose Gold Equipment",
+    "text.autoconfig.nutritionz.option.misc.scorchfulDefaultCompat": "Scorchful",
     "text.autoconfig.nutritionz.option.misc.thebumblezoneDefaultCompat": "The Bumblezone",
     "text.autoconfig.nutritionz.option.misc.tideDefaultCompat": "Tide",
     "text.autoconfig.nutritionz.option.misc.wilderwildDefaultCompat": "Wilder Wild",

--- a/src/main/resources/resourcepacks/fd_farmersdelight_nutritionz/data/farmersdelight/nutrition/farmersdelight_items.json
+++ b/src/main/resources/resourcepacks/fd_farmersdelight_nutritionz/data/farmersdelight/nutrition/farmersdelight_items.json
@@ -27,6 +27,34 @@
         "vitamins": 0,
         "minerals": 0
     },
+    "farmersdelight:milk_bottle": {
+        "carbohydrates": 3,
+        "protein": 2,
+        "fat": 5,
+        "vitamins": 0,
+        "minerals": 0
+    },
+    "farmersdelight:hot_cocoa": {
+        "carbohydrates": 10,
+        "protein": 2,
+        "fat": 5,
+        "vitamins": 0,
+        "minerals": 0
+    },
+    "farmersdelight:apple_cider": {
+        "carbohydrates": 12,
+        "protein": 0,
+        "fat": 0,
+        "vitamins": 12,
+        "minerals": 6
+    },
+    "farmersdelight:melon_juice": {
+        "carbohydrates": 5,
+        "protein": 0,
+        "fat": 0,
+        "vitamins": 15,
+        "minerals": 5
+    },
     "farmersdelight:tomato_sauce": {
         "carbohydrates": 6,
         "protein": 0,

--- a/src/main/resources/resourcepacks/scorchful_nutritionz/data/scorchful/nutrition/scorchful_items.json
+++ b/src/main/resources/resourcepacks/scorchful_nutritionz/data/scorchful/nutrition/scorchful_items.json
@@ -1,0 +1,16 @@
+{
+  "scorchful:water_skin": {
+    "carbohydrates": 0,
+    "protein": 0,
+    "fat": 0,
+    "vitamins": 0,
+    "minerals": 20
+  },
+  "scorchful:cactus_juice": {
+    "carbohydrates": 5,
+    "protein": 0,
+    "fat": 0,
+    "vitamins": 15,
+    "minerals": 5
+  }
+}

--- a/src/main/resources/resourcepacks/scorchful_nutritionz/pack.mcmeta
+++ b/src/main/resources/resourcepacks/scorchful_nutritionz/pack.mcmeta
@@ -1,0 +1,12 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "supported_formats": {
+      "min_inclusive": 1,
+      "max_inclusive": 999
+    },
+    "description": {
+      "text": "scorchful nutritionz compat"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Scorchful compatibility and updates some missing Farmer's Delight items.

I describe how I came up with nutrient values below but feel free to suggest any changes!
- `scorchful:cactus_juice` based on `croptopia:saguaro_juice`
- `scorchful:water_skin` based on Dehydration flasks
- `farmersdelight:milk_bottle` = `minecraft:milk_bucket` / 4
- `farmersdelight:hot_cocoa` add carbs to `farmersdelight:milk_bottle`
- `farmersdelight:apple_cider` based on `vinery:apple_cider`
- `farmersdelight:melon_juice` based on `croptopia:melon_juice`